### PR TITLE
Include loanId in fineract validation request body - SER-1742

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,4 @@
     * Fineract AMS connector
             * [SER-1568] - Project setup + Adding workers for Fineract verification and confirmation
             * [SER-1729] - Fix error that occurs when validation endpoint is called
+            * [SER-1742] - Include loan ID in payload sent to fineract validation endpoint by the fineract AMS connector

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.mifos'
-version = '0.0.1'
+version = '0.0.2'
 description = 'ph-ee-connector-ams-fineract'
 sourceCompatibility = '17'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       start_period: 1m30s
 
   zeebe_ops:
-    image: oaftech.azurecr.io/phee-ns/phee-zeebe-ops:v1.0.1
+    image: oaftech.azurecr.io/phee-ns/phee-zeebe-ops:v1.0.2
     ports:
       - "5001:5000"
     environment:
@@ -27,9 +27,10 @@ services:
         condition: service_healthy
 
   channel-connector:
-    image: oaftech.azurecr.io/phee-ns/ph-ee-connector-channel:v1.1.0
+    image: oaftech.azurecr.io/phee-ns/ph-ee-connector-channel:v1.5.3
     ports:
       - "5002:5000"
+      - "8084:8080"
     environment:
       DFSPIDS: oaf
       LOGGING_LEVEL_ROOT: INFO

--- a/src/main/java/org/mifos/connector/ams/fineract/camel/route/FineractRouteBuilder.java
+++ b/src/main/java/org/mifos/connector/ams/fineract/camel/route/FineractRouteBuilder.java
@@ -6,6 +6,7 @@ import static org.mifos.connector.ams.fineract.camel.config.CamelProperties.CAME
 import static org.mifos.connector.ams.fineract.camel.config.CamelProperties.CHANNEL_REQUEST;
 import static org.mifos.connector.ams.fineract.camel.config.CamelProperties.CURRENCY_VARIABLE_NAME;
 import static org.mifos.connector.ams.fineract.camel.config.CamelProperties.MSISDN_VARIABLE_NAME;
+import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.CUSTOM_DATA;
 import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.EXTERNAL_ID;
 import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.PARTY_LOOKUP_FAILED;
 import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.TRANSACTION_FAILED;
@@ -17,6 +18,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JsonLibrary;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mifos.connector.ams.fineract.data.FineractConfirmationRequestDto;
 import org.mifos.connector.ams.fineract.data.FineractRequestDto;
@@ -74,9 +76,9 @@ public class FineractRouteBuilder extends RouteBuilder {
                     FineractRequestDto verificationRequestDto;
                     if (exchange.getProperty(CHANNEL_REQUEST) != null) {
                         JSONObject channelRequest = (JSONObject) exchange.getProperty(CHANNEL_REQUEST);
-
+                        JSONArray customData = exchange.getProperty(CUSTOM_DATA, JSONArray.class);
                         verificationRequestDto = FineractRequestDto.fromChannelRequest(channelRequest,
-                                exchange.getProperty(TRANSACTION_ID, String.class));
+                                exchange.getProperty(TRANSACTION_ID, String.class), customData);
                     } else {
                         JSONObject payBillRequest = new JSONObject(exchange.getIn().getBody(String.class));
 

--- a/src/main/java/org/mifos/connector/ams/fineract/data/FineractConfirmationRequestDto.java
+++ b/src/main/java/org/mifos/connector/ams/fineract/data/FineractConfirmationRequestDto.java
@@ -35,7 +35,7 @@ public class FineractConfirmationRequestDto extends FineractRequestDto {
     public static FineractConfirmationRequestDto fromChannelRequest(JSONObject channelRequest, String transactionId) {
         FineractConfirmationRequestDto dto = new FineractConfirmationRequestDto();
 
-        BeanUtils.copyProperties(FineractRequestDto.fromChannelRequest(channelRequest, transactionId), dto);
+        BeanUtils.copyProperties(FineractRequestDto.fromChannelRequest(channelRequest, transactionId, null), dto);
 
         return dto;
     }

--- a/src/main/java/org/mifos/connector/ams/fineract/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/connector/ams/fineract/zeebe/ZeebeVariables.java
@@ -16,4 +16,5 @@ public class ZeebeVariables {
     public static final String TRANSACTION_FAILED = "transactionFailed";
     public static final String FINERACT_AMS_ZEEBEE_VALIDATION_WORKER_NAME = "transfer-validation-fineract";
     public static final String FINERACT_AMS_ZEEBEE_SETTLEMENT_WORKER_NAME = "transfer-settlement-fineract";
+    public static final String CUSTOM_DATA = "customData";
 }

--- a/src/main/java/org/mifos/connector/ams/fineract/zeebe/ZeebeWorkers.java
+++ b/src/main/java/org/mifos/connector/ams/fineract/zeebe/ZeebeWorkers.java
@@ -1,6 +1,7 @@
 package org.mifos.connector.ams.fineract.zeebe;
 
 import static org.mifos.connector.ams.fineract.camel.config.CamelProperties.CHANNEL_REQUEST;
+import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.CUSTOM_DATA;
 import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.ERROR_CODE;
 import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.ERROR_DESCRIPTION;
 import static org.mifos.connector.ams.fineract.zeebe.ZeebeVariables.ERROR_INFORMATION;
@@ -23,6 +24,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.support.DefaultExchange;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mifos.connector.ams.fineract.util.ConnectionUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -67,7 +69,11 @@ public class ZeebeWorkers {
                 JSONObject channelRequest = new JSONObject((String) variables.get(CHANNEL_REQUEST));
                 ex.setProperty(CHANNEL_REQUEST, channelRequest);
                 ex.setProperty(TRANSACTION_ID, variables.get(TRANSACTION_ID));
-
+                String customDataString = (String) variables.get(CUSTOM_DATA);
+                if (customDataString != null && !customDataString.isBlank()) {
+                    JSONArray customData = new JSONArray(customDataString);
+                    ex.setProperty(CUSTOM_DATA, customData);
+                }
                 producerTemplate.send("direct:transfer-validation-base", ex);
 
                 checkOperationResultAndSetVariables(PARTY_LOOKUP_FAILED, ex, variables);


### PR DESCRIPTION
## Description

Fineract payment validation API accepts loanId as one of the properties in the request body. This PR retrieves the loanId from the custom data array and forwards it to fineract as part of the validation step.
