### PR TITLE
HOTFIX - Use only version as image tag in main branch builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ steps:
       echo "##vso[task.setvariable variable=VERSION_TAG]$VERSION_TAG"
       IMAGE_TAGS="${VERSION_TAG}.$(date '+%Y.%m.%d').$(Revision)"
       echo "##vso[task.setvariable variable=IMAGE_SEMANTIC_HASH]$IMAGE_TAGS"
-      if [[ "$(Build.SourceBranch)" == "refs/heads/main" ]]; then IMAGE_TAGS="$IMAGE_TAGS,latest"; fi;
+      if [[ "$(Build.SourceBranch)" == "refs/heads/main" ]]; then IMAGE_TAGS="$VERSION_TAG,latest"; fi;
       echo Tags: $IMAGE_TAGS
       echo "##vso[task.setvariable variable=IMAGE_TAGS]$IMAGE_TAGS"
     displayName: Get git tag


### PR DESCRIPTION
## Description

Exclude date and revision number in image tags generated from `main` branch builds
